### PR TITLE
Disassembler

### DIFF
--- a/GLaDOS.cabal
+++ b/GLaDOS.cabal
@@ -27,6 +27,7 @@ library
   exposed-modules:
       AlexToParsec
       ConvertASTtoInstructions
+      Disassembly
       GldsBytecode
       Helpers
       Lexer

--- a/GLaDOS.cabal
+++ b/GLaDOS.cabal
@@ -56,6 +56,7 @@ library
     , bytestring
     , composition-prelude
     , containers
+    , ilist
     , megaparsec
     , monad-loops
     , text
@@ -83,6 +84,7 @@ executable GLaDOS
     , bytestring
     , composition-prelude
     , containers
+    , ilist
     , megaparsec
     , monad-loops
     , text
@@ -110,6 +112,7 @@ executable GLaDOS-cmp
     , bytestring
     , composition-prelude
     , containers
+    , ilist
     , megaparsec
     , monad-loops
     , text
@@ -137,6 +140,7 @@ executable GLaDOS-exe
     , bytestring
     , composition-prelude
     , containers
+    , ilist
     , megaparsec
     , monad-loops
     , text
@@ -169,6 +173,7 @@ test-suite GLaDOS-test
     , containers
     , hspec
     , hspec-megaparsec
+    , ilist
     , megaparsec
     , monad-loops
     , text

--- a/app/Main-all.hs
+++ b/app/Main-all.hs
@@ -1,7 +1,7 @@
 module Main (main) where
 
 import System.Environment(getArgs)
-import VM(vm)
+import VM(vm, disassembler)
 import Compiler(compiler)
 import System.Exit (exitWith, ExitCode (ExitFailure))
 
@@ -9,8 +9,9 @@ type Module = (String, ([String] -> IO (), String))
 
 modules :: [Module]
 modules =
-    [ ("build", (compiler, "Produce an executable from source files"))
-    , ("exec",  (vm,       "Execute a previously built executable"))
+    [ ("build",       (compiler,     "Produce an executable from source files"))
+    , ("exec",        (vm,           "Execute a previously built executable"))
+    , ("disassemble", (disassembler, "Disassemble one or more executables"))
     ]
 
 helpMessage :: String

--- a/app/VM.hs
+++ b/app/VM.hs
@@ -6,8 +6,6 @@ module VM (vm, disassembler) where
 import GldsBytecode(readProgramFromFile)
 import StackMachine (execute', StackProgram)
 import Helpers (headOr, orExitWith, exitWithErrorMessage, orelse, mapMToSnd, )
-import Data.Text (Text)
-import Control.Monad (forM)
 import Disassembly (disassembleFile)
 
 getProgram :: FilePath -> IO StackProgram

--- a/app/VM.hs
+++ b/app/VM.hs
@@ -1,17 +1,30 @@
 {-# OPTIONS_GHC -Wno-missing-signatures #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module VM (vm) where
+module VM (vm, disassembler) where
 
 import GldsBytecode(readProgramFromFile)
-import StackMachine (execute')
-import Helpers (headOr, orExitWith, exitWithErrorMessage, orelse)
+import StackMachine (execute', StackProgram)
+import Helpers (headOr, orExitWith, exitWithErrorMessage, orelse, mapMToSnd, )
+import Data.Text (Text)
+import Control.Monad (forM)
+import Disassembly (disassembleFile)
+
+getProgram :: FilePath -> IO StackProgram
+getProgram filename = do
+    eitherProg <- readProgramFromFile filename
+    eitherProg `orelse` exitWithErrorMessage
 
 vm :: [String] -> IO ()
 vm args = do
     file <- headOr args `orExitWith` "No program to execute"
-    eitherProgram <- readProgramFromFile file
-    program <- eitherProgram `orelse` exitWithErrorMessage
+    program <- getProgram file
     result <- execute' program `orelse` exitWithErrorMessage
 
     print result
+
+disassembler :: [String] -> IO ()
+disassembler [] = exitWithErrorMessage "No input file to disassemble"
+disassembler xs = do
+    stacks <- mapMToSnd getProgram xs
+    mapM_ (putStr . disassembleFile) stacks

--- a/package.yaml
+++ b/package.yaml
@@ -21,6 +21,7 @@ description:         Please see the README on GitHub at <https://github.com/Thib
 
 dependencies:
   - base >= 4.7 && < 5
+  - ilist
   - megaparsec
   - composition-prelude
   - transformers

--- a/src/Disassembly.hs
+++ b/src/Disassembly.hs
@@ -1,5 +1,10 @@
-module Disassembly (disassemble) where
+module Disassembly (disassemble, disassembleFile) where
 import StackMachine (StackProgram)
+
+disassembleFile :: (FilePath, StackProgram) -> String
+disassembleFile (file, stack) = "\n"
+    ++ file ++ ":\n"
+    ++ unlines (map (("  " ++) . show) stack)
 
 disassemble :: StackProgram -> String
 disassemble = unlines . map show

--- a/src/Disassembly.hs
+++ b/src/Disassembly.hs
@@ -1,0 +1,5 @@
+module Disassembly (disassemble) where
+import StackMachine (StackProgram)
+
+disassemble :: StackProgram -> String
+disassemble = unlines . map show

--- a/src/Disassembly.hs
+++ b/src/Disassembly.hs
@@ -1,10 +1,15 @@
 module Disassembly (disassemble, disassembleFile) where
 import StackMachine (StackProgram)
+import Text.Printf (printf)
+import Data.List.Index(indexed)
 
 disassembleFile :: (FilePath, StackProgram) -> String
 disassembleFile (file, stack) = "\n"
     ++ file ++ ":\n"
-    ++ unlines (map (("  " ++) . show) stack)
+    ++ unlines (map showLine (indexed stack))
+    where
+        showLine (idx, instr) = printf "%-*i| %s" longest idx (show instr)
+        longest = length $ show $ length stack
 
 disassemble :: StackProgram -> String
 disassemble = unlines . map show

--- a/src/GldsBytecode.hs
+++ b/src/GldsBytecode.hs
@@ -164,5 +164,5 @@ readProgramFromFile path = do
     bytecode <- BL.readFile path
     let magic = runGet (replicateM 4 getWord8) bytecode
     if magic /= [0x07, 0x0c, 0x04, 0x13]
-        then return $ Left "Invalid magic number"
+        then return $ Left $ path ++ ": Invalid magic number"
         else return $ runGet deserializeProgram (BL.drop 4 bytecode)

--- a/src/Helpers.hs
+++ b/src/Helpers.hs
@@ -10,6 +10,7 @@ module Helpers (
     exitWithErrorMessage,
     orExitWith,
     headOr,
+    mapMToSnd,
 ) where
 
 import Control.Applicative (Alternative((<|>)))
@@ -72,3 +73,10 @@ orExitWith f msg = f msg `orelse` exitWithErrorMessage
 headOr :: [a] -> b -> Either b a
 headOr [] b = Left b
 headOr (x:_) _ = Right x
+
+-- Alternate version of mapM which also returns the values to be mapped
+mapMToSnd :: Monad m => (a -> m b) -> [a] -> m [(a, b)]
+mapMToSnd f = foldr k (return [])
+    where
+        -- k :: a -> m [(a, b)] -> m [(a, b)]
+        k a r = do { x <- f a; xs <- r; return ((a, x):xs) }


### PR DESCRIPTION
This PR adds a rather disassembler to our program, which is able to output the instructions contained in a compiled file.

Here is an example of the output:
```
$ bat test.cl
───────┬─────────────────────────────────────────
       │ File: test.cl
───────┼─────────────────────────────────────────
   1   │ main {
   2   │     return myfunction(18, 24)
   3   │ }
   4   │ 
   5   │ fun myfunction(i32 a, i32 b): i32 {
   6   │     return a + b
   7   │ }
───────┴─────────────────────────────────────────
$ ./glados build test.cl
$ cat -e a.out; echo
^G^L^D^S        ^@^@^R^@^@^@^@^@^X^@^@^@^D^E^@^@^@^E^Bb^@^Ba^@^H^@^E
$ ./glados disassemble a.out  

a.out:
0| NewEnv
1| PushValue (IntValue 18)
2| PushValue (IntValue 24)
3| Call 5
4| Return
5| PushEnv "b"
6| PushEnv "a"
7| OpValue Add
8| Return
$ 
```

Note that each instruction is simply displayed with derived `Show` instance, which we may change at any time to have an output that resembles more a typical disassembly if we want
