### PR TITLE
Use Data.Text in VM and bytecode

### DIFF
--- a/src/ConvertASTtoInstructions.hs
+++ b/src/ConvertASTtoInstructions.hs
@@ -97,8 +97,8 @@ convertExpression declaredVars (ExprAtomic (AtomIdentifier (VarIdentifier name))
     if Set.member name declaredVars
         then Right [PushEnv name]
         else Left $ "Variable '" ++ unpack name ++ "' not declared"
-convertExpression declaredVars (ExprAtomic (AtomIntLiteral n)) = Right [PushValue (IntValue n)]
-convertExpression declaredVars (ExprAtomic (AtomBooleanLiteral b)) = Right [PushValue (BoolValue b)]
+convertExpression _ (ExprAtomic (AtomIntLiteral n)) = Right [PushValue (IntValue n)]
+convertExpression _ (ExprAtomic (AtomBooleanLiteral b)) = Right [PushValue (BoolValue b)]
 
 convertExpression declaredVars (ExprOperation (OpInfix (InfixAdd e1 e2))) = convertInfixOperation declaredVars e2 e1 Add
 convertExpression declaredVars (ExprOperation (OpInfix (InfixSub e1 e2))) = convertInfixOperation declaredVars e2 e1 Sub

--- a/src/StackMachine.hs
+++ b/src/StackMachine.hs
@@ -50,8 +50,8 @@ data Operator
 
 data StackInstruction
     = PushValue Value
-    | PushEnv String
-    | StoreEnv String
+    | PushEnv Text
+    | StoreEnv Text
     | Call Int
     | NewEnv
     | StoreArgs Text Int
@@ -68,7 +68,7 @@ type Stack = [Value]
 
 type StackProgram = [StackInstruction]
 
-type Environment = [(String, Value)]
+type Environment = [(Text, Value)]
 
 type ProgramCounter = Int
 
@@ -83,12 +83,12 @@ pop :: Stack -> Either String (Value, Stack)
 pop (x:xs) = Right (x, xs)
 pop [] = Left "Cannot pop empty stack"
 
-pushEnv :: String -> Environment -> Stack -> Either String Stack
+pushEnv :: Text -> Environment -> Stack -> Either String Stack
 pushEnv name env stack = case lookup name env of
     Just value -> Right (push value stack)
     Nothing -> Left "Cannot find value in environment"
 
-storeEnv :: String -> Environment -> Stack -> Either String Environment
+storeEnv :: Text -> Environment -> Stack -> Either String Environment
 storeEnv name env (value : stack) =
     let updatedEnv = case lookup name env of
                         Just _  -> map (\(k, v) -> if k == name then (k, value) else (k, v)) env

--- a/src/StackMachine.hs
+++ b/src/StackMachine.hs
@@ -197,7 +197,7 @@ execute envStack args prog pc returnStack stack
             Left err -> Left err
         NewEnv -> execute ([]:envStack) args prog (pc + 1) returnStack stack
         Call n -> execute envStack args prog n (pc + 1 : returnStack) stack
-        CallFuncName name -> Left "Should not happen"
+        CallFuncName name -> Left $ "Call to " ++ show name ++ " Should not happen"
         OpValue op -> case applyOperator op stack of
             Left err -> Left err
             Right stack' -> execute envStack args prog (pc + 1) returnStack stack'

--- a/test/CompilerSpec.hs
+++ b/test/CompilerSpec.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -Wno-missing-signatures #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module CompilerSpec (spec) where
 

--- a/test/VmSpec.hs
+++ b/test/VmSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 module VmSpec (spec) where
 
 import Test.Hspec ( hspec, describe, it, shouldBe , shouldThrow, anyException, Spec)


### PR DESCRIPTION
This PR makes good use of Data.Text both in the VM runtime and in the serialisation and deserialisation of the bytecode.

I created a separate PR because I was requesting changes in #38 and thought it would take too many back and forths to get right so I just got to do it myself
