### PR TITLE
Fix function call arguments

### DIFF
--- a/src/Helpers.hs
+++ b/src/Helpers.hs
@@ -11,12 +11,14 @@ module Helpers (
     orExitWith,
     headOr,
     mapMToSnd,
+    myShowList,
 ) where
 
 import Control.Applicative (Alternative((<|>)))
 import Data.Bifunctor (Bifunctor(first))
 import System.Exit (exitWith, ExitCode (ExitFailure))
 import System.IO (stderr, hPutStrLn)
+import Control.Arrow((>>>))
 
 -- Helper function used to create combinator operators
 -- See defintion of (<||>) and (<<|>>) for example uses
@@ -80,3 +82,10 @@ mapMToSnd f = foldr k (return [])
     where
         -- k :: a -> m [(a, b)] -> m [(a, b)]
         k a r = do { x <- f a; xs <- r; return ((a, x):xs) }
+
+myShowList :: Show a => [a] -> String
+myShowList [] = "[]\n"
+myShowList xs = "[\n" ++ showList' xs ++ "  ]\n"
+    where
+        showList' :: Show a => [a] -> String
+        showList' = map (show >>> (++ ",") >>> ("    " ++)) >>> unlines

--- a/src/StackMachine.hs
+++ b/src/StackMachine.hs
@@ -32,8 +32,10 @@ module StackMachine (
 
 import Data.Int (Int64)
 import Data.Text (Text)
+#ifdef DEBUG
 import Debug.Trace
 import Helpers(myShowList)
+#endif
 
 data Value = IntValue Int64 | BoolValue Bool deriving (Show, Eq)
 

--- a/src/StackMachine.hs
+++ b/src/StackMachine.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE CPP #-}
+-- {-# OPTIONS_GHC -DDEBUG #-} -- Uncomment to activate tracing
+
 module StackMachine (
     Value(..),
     Operator(..),
@@ -29,6 +32,8 @@ module StackMachine (
 
 import Data.Int (Int64)
 import Data.Text (Text)
+import Debug.Trace
+import Helpers(myShowList)
 
 data Value = IntValue Int64 | BoolValue Bool deriving (Show, Eq)
 
@@ -177,12 +182,20 @@ execute' :: StackProgram -> Either String Value
 execute' prog = execute [[]] [] prog 0 [] []
 
 execute :: [Environment] -> Args -> StackProgram -> ProgramCounter -> ReturnStack -> Stack -> Either String Value
-execute _ _ [] _ _ stack = case pop stack of
+execute _ _ [] _ _ stack =
+#ifdef DEBUG
+    trace ("End of exec: left with stack: " ++ show stack) $
+#endif
+    case pop stack of
     Right (value, _) -> Right value
     Left err -> Left err
 execute envStack args prog pc returnStack stack
     | pc >= length prog = Left "Program counter out of bounds"
-    | otherwise = case prog !! pc of
+    | otherwise =
+#ifdef DEBUG
+        trace ("exec: " ++ show (prog !! pc) ++ "\n  envStack: " ++ myShowList envStack ++ "\n  args: " ++ show args ++ "\n  pc: " ++ show pc ++ "\n  retStack: " ++ myShowList returnStack ++ "\n  stack: " ++ myShowList stack) $
+#endif
+        case prog !! pc of
         Return -> case returnStack of
             (retAddr:rest) -> execute (tail envStack) args prog retAddr rest stack
             [] -> case pop stack of

--- a/src/StackMachine.hs
+++ b/src/StackMachine.hs
@@ -206,7 +206,7 @@ execute envStack args prog pc returnStack stack
             Right stack' -> execute envStack args prog (pc + 1) returnStack stack'
             Left err -> Left err
         StoreEnv name -> case storeEnv name (head envStack) stack of
-            Right env' -> execute (env':tail envStack) args prog (pc + 1) returnStack stack
+            Right env' -> execute (env':tail envStack) args prog (pc + 1) returnStack (tail stack)
             Left err -> Left err
         NewEnv -> execute ([]:envStack) args prog (pc + 1) returnStack stack
         Call n -> execute envStack args prog n (pc + 1 : returnStack) stack


### PR DESCRIPTION
This PR makes a tiny fix for function call arguments being incorrectly pushed to the envirnoment.

Previously, the `StoreEnv` instruction would rightfully store variables into the environment, but would not pop the the value from the stack, so that when trying to store two values into the environment, the same value would be stored twice.

The diff might be a bit unreadable now, it will get better when #38, #40 and #41 will be merged, so it would be best to wait until those are done before merging this one.

I also added a debugging option in the VM, which I used to find the bug. It can be conditionally activated with a compiler flag.
